### PR TITLE
More precise computation of result from sign, int, frac and exponent …

### DIFF
--- a/parse-float.lisp
+++ b/parse-float.lisp
@@ -199,10 +199,13 @@ string (i.e. cannot start with #\+ or #\-)."
                (if integer-part
                    (if (or (= index end)
                            junk-allowed)
-                       (setf result (* sign (+ (coerce integer-part type)
-					       (* (coerce decimal-part type)
-						  (expt (coerce radix type) (coerce (- digits) type))))
-				       (expt 10 (coerce exponent-part type))))
+                       (setf result (let ((mantissa
+                                           (* sign (+ (coerce integer-part type)
+                                                      (coerce (* decimal-part
+                                                                 (expt radix (- digits))) type)))))
+                                      (if (minusp exponent-part)
+                                        (/ mantissa (expt 10 (- exponent-part)))
+                                        (* mantissa (expt 10 exponent-part)))))
                        (simple-parse-error "junk in string ~S." string))
                    (unless junk-allowed
                      (simple-parse-error "junk in string ~S." string)))


### PR DESCRIPTION
…parts.

I noticed that (parse-float "0.375" :type 'single-float) gave an incorrect value in Lispworks, and running the tests gave a number of other errors. Even ccl and sbcl gave errors for the values "1.25e-3" and "-1.25e-3", for single-float.

This simple change makes all tests succeed on sbcl, ccl and Lispworks.