### PR TITLE
create tests/ directory and rename test package

### DIFF
--- a/parse-float.asd
+++ b/parse-float.asd
@@ -10,10 +10,10 @@
                (:file "parse-float"
 		      :depends-on ("package"))))
 
-(asdf:defsystem #:parse-float-tests
-  :name "parse-float-tests"
+(asdf:defsystem #:parse-float/tests
+  :name "parse-float/tests"
   :description "Tests for parse-float."
   :license "Public Domain"
   :author "Sumant Oemrawsingh"
   :depends-on (#:parse-float #:lisp-unit)
-  :components ((:file "parse-float-tests")))
+  :components ((:file "tests/parse-float")))

--- a/tests/parse-float.lisp
+++ b/tests/parse-float.lisp
@@ -1,9 +1,9 @@
-;;;; parse-float-tests.lisp
+;;;; tests/parse-float.lisp
 
-(defpackage :parse-float-tests
+(defpackage :parse-float/tests
   (:use :common-lisp :lisp-unit :parse-float))
 
-(in-package :parse-float-tests)
+(in-package :parse-float/tests)
 
 (defvar *test-values*
   '(0 1 -1 1/10 -1/10 10 -10 12 -12 1/8 -1/8 123 -123 1/800 -1/800 1234 -1234 1/1600 -1/1600 314159/100000 -314159/100000))


### PR DESCRIPTION
this should make compilation quieter; I only tested this on one deployment, that already had the ASDF system registered, and thus might not have caught some edge cases from different load/compile scenarios.